### PR TITLE
flame_api.sh compatible with running in terminal

### DIFF
--- a/flame_api.sh
+++ b/flame_api.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-cd $HOME/flame_core/flame_API/flame_api
+open_browser () {
+  sleep 5
+  xdg-open "http://127.0.0.1:8000/"
+
+}
+
+FLAME_DIR="$HOME/flame_core/flame_API/flame_api"
+cd "$FLAME_DIR"
 source $HOME/.bashrc
 conda init bash
 source activate flame
-python manage.py runserver --noreload &
-sleep 5
-xdg-open "http://127.0.0.1:8000/"
+open_browser &
+python manage.py runserver --noreload


### PR DESCRIPTION
Running in terminal allows the user to terminate the api easily and safely with ctrl+C (KeyboardInterrupt signal) instead killing it.